### PR TITLE
Update `import_symbol.py`: Re-sort Imports

### DIFF
--- a/src/commands/import_symbol.py
+++ b/src/commands/import_symbol.py
@@ -247,7 +247,15 @@ class ImportSymbolCommand:
             )
 
         self.import_statements = dict(
-            sorted(self.import_statements.items(), key=lambda k: k[0])
+            sorted(
+                self.import_statements.items(),
+                # put imports first, then sort by depth, then by name
+                key=lambda k: (
+                    not k[0].startswith("import "),
+                    k[0].count("."),
+                    k[0],
+                ),
+            )
         )
 
         self.view.erase_status(PyRockConstants.PACKAGE_NAME)


### PR DESCRIPTION
This update re-sorts the imports for the popup menu. Imports starting with "import" are first (`import ...`), then this list is sorted by depth, and then by name.

This way, the least complex (nested) import options are first. In my experience, these are the more likely candidates, especially the `import ...`-style imports.

A downside of this sorting is that it relies on the user to know how nested their module is.

For example:
![image](https://github.com/abhishek72850/pyrock/assets/19216225/96f85786-faed-4cea-9ac1-22a326a70cca)
